### PR TITLE
Add initial ETL skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Healthcare Analytics Pipeline
+
+This repository hosts a basic framework for working with public
+healthcare datasets.  It provides utilities to download sample data,
+clean it for analysis, and serves as the starting point for the
+six‑week data engineering capstone described in the project
+specification.
+
+## Getting Started
+
+1.  Install the requirements with `pip install -r requirements.txt`.
+2.  Run the tests with `pytest`.
+3.  Extend the ETL pipeline in `src/` as the project evolves.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+requests

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,6 @@
+"""Utilities for the healthcare analytics pipeline."""
+
+from .data_acquisition import download_diabetes_dataset
+from .data_cleaning import clean_diabetes_data
+
+__all__ = ["download_diabetes_dataset", "clean_diabetes_data"]

--- a/src/data_acquisition.py
+++ b/src/data_acquisition.py
@@ -1,0 +1,28 @@
+import os
+import pandas as pd
+import requests
+
+DIABETES_URL = "https://archive.ics.uci.edu/ml/machine-learning-databases/00296/dataset_diabetes.zip"
+
+
+def download_diabetes_dataset(dest_dir: str = "data/raw") -> str:
+    """Download the UCI diabetes dataset if it does not exist.
+
+    Parameters
+    ----------
+    dest_dir: str
+        Directory to store the downloaded file.
+
+    Returns
+    -------
+    str
+        Path to the downloaded zip file.
+    """
+    os.makedirs(dest_dir, exist_ok=True)
+    zip_path = os.path.join(dest_dir, "dataset_diabetes.zip")
+    if not os.path.exists(zip_path):
+        response = requests.get(DIABETES_URL, timeout=60)
+        response.raise_for_status()
+        with open(zip_path, "wb") as f:
+            f.write(response.content)
+    return zip_path

--- a/src/data_cleaning.py
+++ b/src/data_cleaning.py
@@ -1,0 +1,18 @@
+import pandas as pd
+
+
+def clean_diabetes_data(df: pd.DataFrame) -> pd.DataFrame:
+    """Simple cleaning for diabetes dataset.
+
+    * Fills missing numeric values with the column mean.
+    * Standardizes column names to snake_case.
+    * Drops duplicate rows.
+    """
+    df = df.copy()
+    numeric_cols = df.select_dtypes(include=["number"]).columns
+    for col in numeric_cols:
+        if df[col].isna().any():
+            df[col] = df[col].fillna(df[col].mean())
+    df.columns = [c.strip().lower().replace(" ", "_") for c in df.columns]
+    df = df.drop_duplicates()
+    return df

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+
+
+def test_repo_has_readme():
+    assert Path("README.md").exists()


### PR DESCRIPTION
## Summary
- initialize healthcare analytics pipeline repo
- add data acquisition and cleaning modules
- add test placeholder
- document getting started steps
- specify pandas and requests as dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bfe8301a0832c81db4bfc9e112b3f